### PR TITLE
Add token management CLI commands

### DIFF
--- a/__tests__/integration/workflow.test.ts
+++ b/__tests__/integration/workflow.test.ts
@@ -1,0 +1,69 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { ZeroContext } from '../../src/context/ZeroContext';
+import { createId, verifyId, deriveId, createProof, verifyProof, generateChallenge, encodeId, freeId } from '../../src/encoding/id';
+import { verifySalt } from '../../src/crypto/salt';
+import { handleCreateCommand } from '../../src/cli/commands/create';
+import { handleChallengeCommand } from '../../src/cli/commands/challenge';
+import { handleProveCommand } from '../../src/cli/commands/prove';
+import { handleVerifyProofCommand } from '../../src/cli/commands/verify-proof';
+
+describe('Integration: Zero Identity workflow', () => {
+  it('creates, verifies, derives and proves identities', () => {
+    const context = ZeroContext.create();
+    const data = { keys: ['user'], values: ['alice'], count: 1 };
+
+    const { id, key } = encodeId(context, data);
+    expect(verifySalt(id.salt)).toBe(true); // salt verification
+
+    // positive verification
+    expect(verifyId(context, id, key, data)).toBe(true);
+
+    // negative verification
+    const badData = { keys: ['user'], values: ['bob'], count: 1 };
+    expect(verifyId(context, id, key, badData)).toBe(false);
+
+    const derivedId = deriveId(context, id, 'auth');
+    expect(Buffer.compare(id.hash, derivedId.hash)).not.toBe(0);
+
+    const challenge = generateChallenge(context);
+    const proof = createProof(context, derivedId, challenge);
+    expect(verifyProof(context, proof, challenge, derivedId)).toBe(true);
+
+    const wrongChallenge = generateChallenge(context);
+    expect(verifyProof(context, proof, wrongChallenge, derivedId)).toBe(false);
+
+    // cleanup
+    freeId(context, id);
+    freeId(context, derivedId);
+    expect(context.activeIds).toBe(0);
+  });
+
+  it('tracks memory usage across ID lifecycle', () => {
+    const context = ZeroContext.create();
+    const start = context.memoryUsed;
+    const data = { keys: ['m'], values: ['n'], count: 1 };
+    const id = createId(context, data);
+    expect(context.memoryUsed).toBeGreaterThan(start);
+    freeId(context, id);
+    expect(context.memoryUsed).toBe(start);
+  });
+
+  it('CLI command flow generates and verifies proofs', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'zero-test-'));
+    const dataFile = path.join(tmpDir, 'data.json');
+    await fs.writeFile(dataFile, JSON.stringify({ keys: ['x'], values: ['y'], count: 1 }));
+
+    const idFile = path.join(tmpDir, 'id.zid');
+    await handleCreateCommand({ input: dataFile, output: idFile, salt: '32', algorithm: 'sha512', format: 'text', verbose: false });
+
+    const challengeFile = path.join(tmpDir, 'challenge.bin');
+    await handleChallengeCommand({ output: challengeFile, size: '32' });
+
+    const proofFile = path.join(tmpDir, 'proof.bin');
+    await handleProveCommand({ input: idFile, challenge: challengeFile, output: proofFile, format: 'binary', verbose: false });
+
+    await expect(handleVerifyProofCommand({ input: proofFile, challenge: challengeFile, id: idFile })).resolves.not.toThrow();
+  });
+});

--- a/__tests__/unit/cli-tokens.spec.ts
+++ b/__tests__/unit/cli-tokens.spec.ts
@@ -1,0 +1,49 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { ZeroContext } from '../../src/context/ZeroContext';
+import { AuditLogger } from '../../src/context/AuditLogger';
+import { registerCreateTokenCommand } from '../../src/cli/commands/create-token';
+import { registerRevokeTokenCommand } from '../../src/cli/commands/revoke-token';
+import { registerRotateTokenCommand } from '../../src/cli/commands/rotate-token';
+import { registerListTokensCommand } from '../../src/cli/commands/list-tokens';
+import { Command } from 'commander';
+import { FileHandler } from '../../src/cli/handlers/FileHandler';
+import { createId } from '../../src/encoding/id';
+
+function createProgram(ctx: ZeroContext, logger: AuditLogger): Command {
+  const program = new Command();
+  registerCreateTokenCommand(program, ctx, logger);
+  registerRevokeTokenCommand(program, ctx, logger);
+  registerRotateTokenCommand(program, ctx, logger);
+  registerListTokensCommand(program, ctx);
+  return program;
+}
+
+describe('CLI token commands', () => {
+  it('creates, revokes and rotates tokens', async () => {
+    const ctx = ZeroContext.create();
+    const logger = new AuditLogger(path.join(os.tmpdir(), 'audit.log'));
+    const program = createProgram(ctx, logger);
+
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'cli-token-'));
+    const zidFile = path.join(tmp, 'id.zid');
+    const tokenFile = path.join(tmp, 'tok.txt');
+    const data = { keys: ['a'], values: ['b'], count: 1 };
+    const id = createId(ctx, data);
+    await FileHandler.writeOutput(zidFile, { id });
+
+    await program.parseAsync(['node', 'test', 'create-token', '-i', zidFile, '-o', tokenFile]);
+    const token = (await fs.readFile(tokenFile, 'utf8')).trim();
+    expect(token.length).toBeGreaterThan(0);
+
+    await program.parseAsync(['node', 'test', 'revoke-token', '-i', tokenFile]);
+    const listed = ctx.tokenManager.listTokens(JSON.stringify(id));
+    expect(listed[0].revoked).toBe(true);
+
+    await fs.writeFile(tokenFile, token);
+    await program.parseAsync(['node', 'test', 'rotate-token', '-i', tokenFile, '-z', zidFile, '-o', tokenFile]);
+    const rotated = (await fs.readFile(tokenFile, 'utf8')).trim();
+    expect(rotated).not.toBe(token);
+  });
+});

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -18,6 +18,8 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { registerCommands } from './commands/index.js';
+import { ZeroContext } from '@/context/ZeroContext.js';
+import { AuditLogger } from '@/context/AuditLogger.js';
 import { ZeroError } from '@/errors/ZeroError.js';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
@@ -36,6 +38,8 @@ const PROGRAM_NAME = 'zero';
  */
 export function createCLI(): Command {
   const program = new Command();
+  const context = ZeroContext.create();
+  const logger = new AuditLogger('audit.log');
   
   // Configure global settings
   program
@@ -46,7 +50,7 @@ export function createCLI(): Command {
     .helpOption('-h, --help', 'Show help information');
   
   // Register all commands
-  registerCommands(program);
+  registerCommands(program, context, logger);
   
   // Add help examples
   program.on('--help', () => {

--- a/src/cli/commands/create-token.ts
+++ b/src/cli/commands/create-token.ts
@@ -1,0 +1,27 @@
+import { Command } from 'commander';
+import { ZeroContext } from '@/context/ZeroContext.js';
+import { FileHandler } from '../handlers/FileHandler.js';
+import { AuditLogger } from '@/context/AuditLogger.js';
+
+export interface TokenCommandOptions {
+  input: string;
+  output?: string;
+}
+
+export function registerCreateTokenCommand(program: Command, ctx: ZeroContext, logger: AuditLogger): Command {
+  return program
+    .command('create-token')
+    .description('Generate a new ZID token')
+    .requiredOption('-i, --input <file>', 'ZID file to use')
+    .option('-o, --output <file>', 'Output file for token')
+    .action(async (options: TokenCommandOptions) => {
+      const id = await FileHandler.readId(options.input);
+      const tokenInfo = ctx.tokenManager.createToken(JSON.stringify(id));
+      logger.log('create-token', JSON.stringify(id), tokenInfo.token);
+      if (options.output) {
+        await FileHandler.writeText(options.output, tokenInfo.token);
+      } else {
+        console.log(tokenInfo.token);
+      }
+    });
+}

--- a/src/cli/commands/export-zid.ts
+++ b/src/cli/commands/export-zid.ts
@@ -1,0 +1,29 @@
+import { Command } from 'commander';
+import { FileHandler } from '../handlers/FileHandler.js';
+import { ZeroParser, FileFormat } from '@/parser/index.js';
+
+export interface ExportOptions {
+  input: string;
+  output?: string;
+  format?: string;
+}
+
+export function registerExportZidCommand(program: Command): Command {
+  return program
+    .command('export-zid')
+    .description('Export a ZID in base64 or JSON')
+    .requiredOption('-i, --input <file>', 'ZID file')
+    .option('-o, --output <file>', 'Output file')
+    .option('--format <base64|json>', 'Output format', 'json')
+    .action(async (opts: ExportOptions) => {
+      const id = await FileHandler.readId(opts.input);
+      const parser = new ZeroParser();
+      const format = opts.format === 'base64' ? FileFormat.TEXT : FileFormat.JSON;
+      const serialized = parser.serializeData({ id }, format);
+      if (opts.output) {
+        await FileHandler.writeText(opts.output, serialized.toString());
+      } else {
+        console.log(serialized.toString());
+      }
+    });
+}

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -12,13 +12,19 @@ import { registerVerifyProofCommand } from './verify-proof.js';
 import { registerInfoCommand } from './info.js';
 import { registerStegoCommand } from './stego.js';
 import { registerConfigCommand } from './config.js';
+import { registerCreateTokenCommand } from './create-token.js';
+import { registerRevokeTokenCommand } from './revoke-token.js';
+import { registerRotateTokenCommand } from './rotate-token.js';
+import { registerListTokensCommand } from './list-tokens.js';
+import { registerRemoveZidCommand } from './remove-zid.js';
+import { registerExportZidCommand } from './export-zid.js';
 
 /**
  * Registers all CLI commands
  * 
  * @param program - Commander program instance
  */
-export function registerCommands(program: Command): void {
+export function registerCommands(program: Command, context: any, logger: any): void {
   // Register individual commands
   registerCreateCommand(program);
   registerDeriveCommand(program);
@@ -26,6 +32,12 @@ export function registerCommands(program: Command): void {
   registerChallengeCommand(program);
   registerProveCommand(program);
   registerVerifyProofCommand(program);
+  registerCreateTokenCommand(program, context, logger);
+  registerRevokeTokenCommand(program, context, logger);
+  registerRotateTokenCommand(program, context, logger);
+  registerListTokensCommand(program, context);
+  registerRemoveZidCommand(program, context, logger);
+  registerExportZidCommand(program);
   registerInfoCommand(program);
   registerStegoCommand(program);
   registerConfigCommand(program);
@@ -41,3 +53,9 @@ export * from './verify-proof.js';
 export * from './info.js';
 export * from './stego.js';
 export * from './config.js';
+export * from './create-token.js';
+export * from './revoke-token.js';
+export * from './rotate-token.js';
+export * from './list-tokens.js';
+export * from './remove-zid.js';
+export * from './export-zid.js';

--- a/src/cli/commands/list-tokens.ts
+++ b/src/cli/commands/list-tokens.ts
@@ -1,0 +1,19 @@
+import { Command } from 'commander';
+import { ZeroContext } from '@/context/ZeroContext.js';
+import { FileHandler } from '../handlers/FileHandler.js';
+
+export interface ListOptions { input: string; }
+
+export function registerListTokensCommand(program: Command, ctx: ZeroContext): Command {
+  return program
+    .command('list-tokens')
+    .description('List tokens for a ZID')
+    .requiredOption('-i, --input <file>', 'ZID file')
+    .action(async (opts: ListOptions) => {
+      const zidData = await FileHandler.readId(opts.input);
+      const tokens = ctx.tokenManager.listTokens(JSON.stringify(zidData));
+      tokens.forEach(t => {
+        console.log(`${t.token} ${t.revoked ? '(revoked)' : ''}`);
+      });
+    });
+}

--- a/src/cli/commands/remove-zid.ts
+++ b/src/cli/commands/remove-zid.ts
@@ -1,0 +1,18 @@
+import { Command } from 'commander';
+import { ZeroContext } from '@/context/ZeroContext.js';
+import { FileHandler } from '../handlers/FileHandler.js';
+import { AuditLogger } from '@/context/AuditLogger.js';
+
+export interface RemoveOptions { input: string; }
+
+export function registerRemoveZidCommand(program: Command, ctx: ZeroContext, logger: AuditLogger): Command {
+  return program
+    .command('remove-zid')
+    .description('Delete a ZID and revoke its tokens')
+    .requiredOption('-i, --input <file>', 'ZID file')
+    .action(async (opts: RemoveOptions) => {
+      const zidData = await FileHandler.readId(opts.input);
+      ctx.tokenManager.removeZid(JSON.stringify(zidData));
+      logger.log('remove-zid', JSON.stringify(zidData));
+    });
+}

--- a/src/cli/commands/revoke-token.ts
+++ b/src/cli/commands/revoke-token.ts
@@ -1,0 +1,20 @@
+import { Command } from 'commander';
+import { ZeroContext } from '@/context/ZeroContext.js';
+import { FileHandler } from '../handlers/FileHandler.js';
+import { AuditLogger } from '@/context/AuditLogger.js';
+
+export interface RevokeOptions {
+  input: string;
+}
+
+export function registerRevokeTokenCommand(program: Command, ctx: ZeroContext, logger: AuditLogger): Command {
+  return program
+    .command('revoke-token')
+    .description('Revoke an existing token')
+    .requiredOption('-i, --input <file>', 'Token file')
+    .action(async (opts: RevokeOptions) => {
+      const token = (await FileHandler.readText(opts.input)).trim();
+      ctx.tokenManager.revokeToken(token);
+      logger.log('revoke-token', '', token);
+    });
+}

--- a/src/cli/commands/rotate-token.ts
+++ b/src/cli/commands/rotate-token.ts
@@ -1,0 +1,31 @@
+import { Command } from 'commander';
+import { ZeroContext } from '@/context/ZeroContext.js';
+import { FileHandler } from '../handlers/FileHandler.js';
+import { AuditLogger } from '@/context/AuditLogger.js';
+
+export interface RotateOptions {
+  input: string;
+  output?: string;
+  zid: string;
+}
+
+export function registerRotateTokenCommand(program: Command, ctx: ZeroContext, logger: AuditLogger): Command {
+  return program
+    .command('rotate-token')
+    .description('Rotate a token, revoking the old one')
+    .requiredOption('-i, --input <file>', 'Existing token file')
+    .requiredOption('-z, --zid <file>', 'ZID file for context')
+    .option('-o, --output <file>', 'Output path for new token')
+    .action(async (opts: RotateOptions) => {
+      const token = (await FileHandler.readText(opts.input)).trim();
+      const zidData = await FileHandler.readId(opts.zid);
+      const newInfo = ctx.tokenManager.rotateToken(token, JSON.stringify(zidData));
+      if (!newInfo) return;
+      logger.log('rotate-token', JSON.stringify(zidData), newInfo.token);
+      if (opts.output) {
+        await FileHandler.writeText(opts.output, newInfo.token);
+      } else {
+        console.log(newInfo.token);
+      }
+    });
+}

--- a/src/cli/handlers/FileHandler.ts
+++ b/src/cli/handlers/FileHandler.ts
@@ -342,4 +342,38 @@ export class FileHandler {
       );
     }
   }
+
+  /**
+   * Writes plain text to a file
+   */
+  public static async writeText(outputPath: string, text: string): Promise<void> {
+    try {
+      const dir = path.dirname(outputPath);
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(outputPath, text, 'utf8');
+    } catch (err) {
+      throw new ZeroError(
+        ZeroErrorCode.IO_ERROR,
+        `Failed to write text to: ${outputPath}`,
+        { outputPath },
+        err instanceof Error ? err : undefined
+      );
+    }
+  }
+
+  /**
+   * Reads plain text from a file
+   */
+  public static async readText(filePath: string): Promise<string> {
+    try {
+      return await fs.readFile(filePath, 'utf8');
+    } catch (err) {
+      throw new ZeroError(
+        ZeroErrorCode.IO_ERROR,
+        `Failed to read file: ${filePath}`,
+        { filePath },
+        err instanceof Error ? err : undefined
+      );
+    }
+  }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,14 +6,20 @@
  */
 
 export { createCLI, main, program } from './cli.js';
-export { 
+export {
   registerCreateCommand,
-  registerDeriveCommand, 
+  registerDeriveCommand,
   registerChallengeCommand,
   registerProveCommand,
   registerVerifyCommand,
   registerVerifyProofCommand,
   registerInfoCommand,
-  registerStegoCommand
+  registerStegoCommand,
+  registerCreateTokenCommand,
+  registerRevokeTokenCommand,
+  registerRotateTokenCommand,
+  registerListTokensCommand,
+  registerRemoveZidCommand,
+  registerExportZidCommand
 } from './commands/index.js';
 

--- a/src/context/AuditLogger.ts
+++ b/src/context/AuditLogger.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+
+export class AuditLogger {
+  constructor(private logPath: string) {}
+
+  log(operation: string, zid: string, token?: string): void {
+    const entry = {
+      timestamp: new Date().toISOString(),
+      zid,
+      operation,
+      token
+    };
+    try {
+      fs.mkdirSync(path.dirname(this.logPath), { recursive: true });
+      fs.appendFileSync(this.logPath, JSON.stringify(entry) + '\n');
+    } catch {
+      // ignore logging errors
+    }
+  }
+}

--- a/src/context/TokenManager.ts
+++ b/src/context/TokenManager.ts
@@ -1,0 +1,51 @@
+import crypto from "crypto";
+export interface TokenInfo {
+  token: string;
+  revoked: boolean;
+  created: number;
+}
+
+export class TokenManager {
+  private tokens: Map<string, TokenInfo> = new Map();
+  private tokensByZid: Map<string, Set<string>> = new Map();
+
+  createToken(zid: string): TokenInfo {
+    const token = Buffer.from(crypto.randomBytes(32)).toString('base64');
+    const info: TokenInfo = { token, revoked: false, created: Date.now() };
+    this.tokens.set(token, info);
+    if (!this.tokensByZid.has(zid)) {
+      this.tokensByZid.set(zid, new Set());
+    }
+    this.tokensByZid.get(zid)!.add(token);
+    return info;
+  }
+
+  revokeToken(token: string): boolean {
+    const info = this.tokens.get(token);
+    if (!info || info.revoked) return false;
+    info.revoked = true;
+    return true;
+  }
+
+  rotateToken(token: string, zid: string): TokenInfo | null {
+    const info = this.tokens.get(token);
+    if (!info || info.revoked) return null;
+    this.revokeToken(token);
+    return this.createToken(zid);
+  }
+
+  listTokens(zid: string): TokenInfo[] {
+    const tokens = this.tokensByZid.get(zid);
+    if (!tokens) return [];
+    return Array.from(tokens).map(t => this.tokens.get(t)!).filter(Boolean);
+  }
+
+  removeZid(zid: string): void {
+    const tokens = this.tokensByZid.get(zid);
+    if (!tokens) return;
+    for (const token of tokens) {
+      this.revokeToken(token);
+    }
+    this.tokensByZid.delete(zid);
+  }
+}

--- a/src/context/ZeroContext.ts
+++ b/src/context/ZeroContext.ts
@@ -9,6 +9,7 @@ import { ZeroError, ZeroErrorCode } from '@/errors/index.js';
 import { CryptoFlags } from '@/types/common.js';
 import { CRYPTO, ENCODING, VERSION } from '@/utils/constants.js';
 import { deepFreeze, secureAlloc, secureFree } from '@/utils/index.js';
+import { TokenManager } from './TokenManager.js';
 import { 
     IZeroContext,
     IZeroConfig,
@@ -76,6 +77,11 @@ import { ZeroMap } from './ZeroMap.js';
      * Optional user-defined data
      */
     public userData?: unknown;
+
+    /**
+     * Token manager for ZID tokens
+     */
+    public readonly tokenManager: TokenManager;
     
     /**
      * Creates a new ZeroContext instance
@@ -102,6 +108,7 @@ import { ZeroMap } from './ZeroMap.js';
       this.memoryUsed = 0;
       this.createdTime = Date.now();
       this.flags = flags;
+      this.tokenManager = new TokenManager();
       
       // Freeze config to prevent modifications
       deepFreeze(this.config);

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -46,6 +46,8 @@ export {
 export {
   ZeroHashTable,
 } from './ZeroHashTable.js';
+export { TokenManager, TokenInfo } from './TokenManager.js';
+export { AuditLogger } from "./AuditLogger.js";
 
 // Additional utility functions for context module
 


### PR DESCRIPTION
## Summary
- extend ZeroContext with TokenManager and AuditLogger
- implement CLI commands for ZID token creation and lifecycle
- log token operations in an audit trail
- provide unit tests for CLI token commands

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686309bd1da483278721dc0bfe2f9a02